### PR TITLE
Add alignTo methods to TimeUnit

### DIFF
--- a/src/main/groovy/de/dkfz/roddy/tools/TimeUnit.groovy
+++ b/src/main/groovy/de/dkfz/roddy/tools/TimeUnit.groovy
@@ -79,9 +79,9 @@ class TimeUnit {
             String[] newStrList = ["00", "00", "00", "00"]
 
             //Check if the string contains anything else than the unit and dots.
-            String validationString = str[-1].isNumber() ? str : str[0 .. -2]
+            String validationString = str[-1].isNumber() ? str : str[0..-2]
             for (int i = 0; i < validationString.size(); i++) {
-                if(validationString[i].isNumber() || validationString[i] == ".") continue
+                if (validationString[i].isNumber() || validationString[i] == ".") continue
                 throw new NumberFormatException("The unit string ${validationString} may only contain dots and number followed by a unit.")
             }
 
@@ -139,7 +139,7 @@ class TimeUnit {
     }
 
     static TimeUnit fromDuration(Duration duration) {
-        return new TimeUnit(duration.getSeconds()+"s")
+        return new TimeUnit(duration.getSeconds() + "s")
     }
 
     Duration asDuration() {
@@ -150,5 +150,25 @@ class TimeUnit {
     @Override
     String toString() {
         return timeString
+    }
+
+    String alignToHours() {
+        String[] split = timeString.split("[:]")
+        String result = [split[0].toInteger() * 24 + split[1].toInteger(), split[2], split[3]].join(":")
+        return result
+    }
+
+    String alignToMinutes() {
+        String[] split = timeString.split("[:]")
+        String result = [
+                (split[0].toInteger() * 24 + split[1].toInteger()) * 60 + split[2].toInteger(), split[3]
+        ].join(":")
+        return result
+    }
+
+    String alignToSeconds() {
+        String[] split = timeString.split("[:]")
+        String result = ((split[0].toInteger() * 24 + split[1].toInteger()) * 60 + split[2].toInteger()) * 60 + split[3].toInteger()
+        return result
     }
 }

--- a/src/main/groovy/de/dkfz/roddy/tools/TimeUnit.groovy
+++ b/src/main/groovy/de/dkfz/roddy/tools/TimeUnit.groovy
@@ -152,13 +152,13 @@ class TimeUnit {
         return timeString
     }
 
-    String alignToHours() {
+    String toHourString() {
         String[] split = timeString.split("[:]")
         String result = [split[0].toInteger() * 24 + split[1].toInteger(), split[2], split[3]].join(":")
         return result
     }
 
-    String alignToMinutes() {
+    String toMinuteString() {
         String[] split = timeString.split("[:]")
         String result = [
                 (split[0].toInteger() * 24 + split[1].toInteger()) * 60 + split[2].toInteger(), split[3]
@@ -166,7 +166,7 @@ class TimeUnit {
         return result
     }
 
-    String alignToSeconds() {
+    String toSecondString() {
         String[] split = timeString.split("[:]")
         String result = ((split[0].toInteger() * 24 + split[1].toInteger()) * 60 + split[2].toInteger()) * 60 + split[3].toInteger()
         return result

--- a/src/test/groovy/de/dkfz/roddy/TimeUnitTest.groovy
+++ b/src/test/groovy/de/dkfz/roddy/TimeUnitTest.groovy
@@ -66,6 +66,23 @@ public class TimeUnitTest {
         }
     }
 
+    @Test
+    void testAlignToHours() throws Exception {
+        assert new TimeUnit("07:12:00:00").alignToHours() == "${7 * 24 + 12}:00:00"
+    }
+
+    @Test
+    void testAlignToMinutes() throws Exception {
+        assert new TimeUnit("07:12:00:00").alignToMinutes() == "${(7 * 24 + 12)*60}:00"
+        assert new TimeUnit("07:12:10:20").alignToMinutes() == "${(7 * 24 + 12)*60 + 10}:20"
+    }
+
+    @Test
+    void testAlignToSeconds() throws Exception {
+        assert new TimeUnit("07:12:00:00").alignToSeconds() == "${(7 * 24 + 12)*3600}"
+        assert new TimeUnit("07:12:10:20").alignToSeconds() == "${(7 * 24 + 12)*3600 + 620}"
+    }
+
     @Test(expected = NumberFormatException)
     public void testInvalidWalltimeString2() {
         new TimeUnit("3:5.25")

--- a/src/test/groovy/de/dkfz/roddy/TimeUnitTest.groovy
+++ b/src/test/groovy/de/dkfz/roddy/TimeUnitTest.groovy
@@ -67,20 +67,20 @@ public class TimeUnitTest {
     }
 
     @Test
-    void testAlignToHours() throws Exception {
-        assert new TimeUnit("07:12:00:00").alignToHours() == "${7 * 24 + 12}:00:00"
+    void testToHourString() throws Exception {
+        assert new TimeUnit("07:12:00:00").toHourString() == "${7 * 24 + 12}:00:00"
     }
 
     @Test
-    void testAlignToMinutes() throws Exception {
-        assert new TimeUnit("07:12:00:00").alignToMinutes() == "${(7 * 24 + 12)*60}:00"
-        assert new TimeUnit("07:12:10:20").alignToMinutes() == "${(7 * 24 + 12)*60 + 10}:20"
+    void testToMinuteString() throws Exception {
+        assert new TimeUnit("07:12:00:00").toMinuteString() == "${(7 * 24 + 12)*60}:00"
+        assert new TimeUnit("07:12:10:20").toMinuteString() == "${(7 * 24 + 12)*60 + 10}:20"
     }
 
     @Test
-    void testAlignToSeconds() throws Exception {
-        assert new TimeUnit("07:12:00:00").alignToSeconds() == "${(7 * 24 + 12)*3600}"
-        assert new TimeUnit("07:12:10:20").alignToSeconds() == "${(7 * 24 + 12)*3600 + 620}"
+    void testToSecondString() throws Exception {
+        assert new TimeUnit("07:12:00:00").toSecondString() == "${(7 * 24 + 12)*3600}"
+        assert new TimeUnit("07:12:10:20").toSecondString() == "${(7 * 24 + 12)*3600 + 620}"
     }
 
     @Test(expected = NumberFormatException)


### PR DESCRIPTION
Necessary e.g. for the GridEngine support in BatchEuphoria. GE does not accept 00:00:00:00 format for walltime but needs 000:00:00