### PR TITLE
Split code from Version file into separate files. Version compatibili…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 apply plugin: 'groovy'
 apply plugin: 'maven'
 
-group = "com.github.eilslabs"
+group = "com.github.theroddywms"
 
 
 /*

--- a/src/main/groovy/de/dkfz/roddy/tools/versions/CompatibilityChecker.groovy
+++ b/src/main/groovy/de/dkfz/roddy/tools/versions/CompatibilityChecker.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
+package de.dkfz.roddy.tools.versions
+
+import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
+import groovy.transform.TypeCheckingMode
+
+@CompileStatic
+class CompatibilityChecker {
+
+    final static VersionLevel defaultCompatibilityLevel = VersionLevel.REVISION
+
+    /** The compatibility-level is the lowest VersionLevel (order as in the VersionLevel enum; with MAJOR first (low)
+     *  and REVISION last (high)) two compared versions need to be identical in, to be considered compatible.
+     *
+     *  By default, two versions are compatible, if they only differ in the REVISION. The default compatibility-level
+     *  is therefore VersionLevel.PATCH. For instance, by default the versions 1.1.1-0 and 1.1.1-1 are considered
+     *  compatible, but 1.1.2-0 is not compatible to the first two. If the compatibility level for the comparisons is
+     *  set to null, then all versions are compatible.
+     *
+     *  The second way to declare compatibility is by explicitly declaring compatibility intervals. If there is any
+     *  interval that contains both versions (this and the other) then the two versions are compatible. Also these
+     *  checks account for implicit compatibility defined by the compatibility level. Note that, if two versions are
+     *  compatible then all intermediate versions are also compatible. Therefore, compatibility generates an equivalence
+     *  relation on versions (reflexive, symmetric, transitive).
+     */
+
+    /** This is used to ensure transitivity of compatibility */
+    @CompileStatic(TypeCheckingMode.SKIP)
+    private static Collection<VersionInterval> mergeOverlappingIntervals(final Collection<VersionInterval> intervals,
+                                                                         VersionLevel level = defaultCompatibilityLevel) {
+        return intervals.toSorted().inject(new LinkedList<VersionInterval>()) { List<VersionInterval> result, VersionInterval next ->
+            if (result.isEmpty()) {
+                [next]
+            } else {
+                def merged = result.first().merge(next, level)
+                if (merged.isPresent()) {
+                    result.drop(1)
+                    result.add(0, merged.get())
+                } else {
+                    result.add(0, next)
+                }
+                result
+            }
+        }
+    }
+
+    /**
+     *
+     * @param other
+     * @param compatibilities   List of compatibility intervals. Will be curated into equivalence classes.
+     * @param level             Compatibility level used for implicit compatibilities. By default REVISIONs are
+     *                          compatible. A value of "null" serves to let all versions be compatible.
+     * @return
+     */
+    static boolean compatibleTo(final Version first, final Version second, final Collection<VersionInterval> compatibilities,
+                                VersionLevel level = defaultCompatibilityLevel) {
+        if (null == level) {
+            return true
+        }
+        def mergeCompatibilities = mergeOverlappingIntervals(compatibilities, level)
+        Boolean sameCompatibilityLevel = first.compareTo(second, level) == 0
+        if (sameCompatibilityLevel) {
+            return true
+        } else {
+            VersionInterval sharedInterval = mergeCompatibilities.find { interval ->
+                interval.contains(first, level) && interval.contains(second, level)
+            }
+            return null != sharedInterval
+        }
+    }
+
+    @CompileDynamic
+    static boolean isBackwardsCompatibleTo(final Version query, final Version base,
+                                    VersionLevel firstNonEqualLevel = defaultCompatibilityLevel) {
+        assert(firstNonEqualLevel != VersionLevel.MAJOR)
+        return query.compareTo(base, firstNonEqualLevel.previous()) == 0 &&
+                query[firstNonEqualLevel] >= base[firstNonEqualLevel]
+    }
+
+
+}

--- a/src/main/groovy/de/dkfz/roddy/tools/versions/Version.groovy
+++ b/src/main/groovy/de/dkfz/roddy/tools/versions/Version.groovy
@@ -1,73 +1,17 @@
 /*
- * Copyright (c) 2016 eilslabs.
+ * Copyright (c) 2016 German Cancer Research Center (DKFZ).
  *
- * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ * Distributed under the MIT License (license terms are at https://www.github.com/TheRoddyWMS/RoddyToolLib/LICENSE.txt).
  */
 
 package de.dkfz.roddy.tools.versions
 
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
-import groovy.transform.TypeCheckingMode
 
 import java.text.ParseException
 import java.util.regex.Matcher
 import java.util.regex.Pattern
-
-/**
- * VersionInterval allow to check whether a Version is within the interval. To simplify the implementation of
- * version compatibility given a set of compatibility intervals as equivalence class (in particular with respect
- * to transitivity) version interval are Comparable and can be merged (when overlapping).
- */
-@CompileStatic
-class VersionInterval implements Comparable<VersionInterval> {
-    final Version from
-    final Version to
-
-    VersionInterval(Version from, Version to) {
-        if (from <= to) {
-            this.from = from
-            this.to = to
-        } else {
-            this.to = from
-            this.from = to
-        }
-    }
-
-    boolean contains(final Version query, Version.VersionLevel level = Version.defaultCompatibilityLevel) {
-        return this.from.compareTo(query, level) <= 0 &&
-                this.to.compareTo(query, level) >= 0
-    }
-
-    boolean overlaps(VersionInterval other, Version.VersionLevel level = Version.defaultCompatibilityLevel) {
-        /** Relations can be partial overlap, containment of one in the other and disjunction. */
-        return this.contains(other.from, level) || this.contains(other.to, level) ||
-                other.contains(this.from, level) || other.contains(this.to, level)
-    }
-
-    /** Lexicographic ordering of VersionIntervals. */
-    @Override
-    int compareTo(VersionInterval o) {
-        return compareTo(o, Version.defaultCompatibilityLevel)
-    }
-    int compareTo(VersionInterval other, Version.VersionLevel level) {
-        return this.from.compareTo(other.from, level) ?: this.to.compareTo(other.to, level)
-    }
-
-    /** Attempt to merge two interval, if they overlap. Otherwise return Optional.empty(). */
-    Optional<VersionInterval> merge(VersionInterval other, Version.VersionLevel level = Version.defaultCompatibilityLevel) {
-        if (this.overlaps(other, level)) {
-            return Optional.of(new VersionInterval([this.from, other.from].min(), [this.to, other.to].max()))
-        } else {
-            return Optional.empty()
-        }
-    }
-
-    @Override
-    String toString() {
-        "[${this.from}, ${this.to}]"
-    }
-}
 
 /**
  * Version class for semantic versioning. In particular a disciplined way of increasing versions at different semantic
@@ -80,49 +24,11 @@ class VersionInterval implements Comparable<VersionInterval> {
 @CompileStatic
 class Version implements Comparable<Version> {
 
-    static enum VersionLevel {
-        MAJOR,
-        MINOR,
-        PATCH,
-        REVISION;
-
-        static VersionLevel fromInteger(int x) {
-            switch(x) {
-                case 0:
-                    return MAJOR;
-                case 1:
-                    return MINOR;
-                case 2:
-                    return PATCH;
-                case 3:
-                    return REVISION;
-                default:
-                    throw new NumberFormatException("Cannot interpret integer ${x} as VersionLevel")
-            }
-            return null;
-        }
-
-        /** With the next() and previous() methods VersionLevel can be used in Groovy range expression alla
-         *  PATCH..REVISION. Taken from https://kousenit.org/2008/03/19/turning-java-enums-into-groovy-ranges
-         */
-        VersionLevel next() {
-            VersionLevel[] vals = VersionLevel.values()
-            return vals[(this.ordinal() + 1) % vals.length]
-        }
-
-        VersionLevel previous() {
-            VersionLevel[] vals = VersionLevel.values()
-            return vals[(this.ordinal() - 1 + vals.length) % vals.length]
-        }
-    }
-
     final Integer major
     final Integer minor
     final Integer patch
     final Integer revision
 
-    /** Global default compatibility level. */
-    static final VersionLevel defaultCompatibilityLevel = VersionLevel.PATCH
 
     Version (Integer major, Integer minor, Integer patch, Integer revision = 0) {
         this.major = major
@@ -164,26 +70,17 @@ class Version implements Comparable<Version> {
         return result
     }
 
-    private static final Pattern versionPattern = Pattern.compile(/^(\d+)\.(\d+)\.(\d+)(-(\d+))?$/)
+    private static final Pattern versionPattern = Pattern.compile(/^(\d+)(?:\.(\d+)(?:\.(\d+)(?:-(\d+))?)?)?$/)
 
     static Version fromString (String versionString) {
         Matcher matcher = versionPattern.matcher(versionString)
         if (matcher.matches()) {
-            if (null != matcher.group(5)) {
-                return new Version(
-                        matcher.group(1).toInteger(),
-                        matcher.group(2).toInteger(),
-                        matcher.group(3).toInteger(),
-                        matcher.group(5).toInteger(), // the inner group of "(-(\d))+"
-                )
-            } else {
-                return new Version(
-                        matcher.group(1).toInteger(),
-                        matcher.group(2).toInteger(),
-                        matcher.group(3).toInteger(),
-                        0
-                )
-            }
+            return new Version(
+                    matcher.group(1).toInteger(),
+                    matcher.group(2) ? matcher.group(2).toInteger() : 0,
+                    matcher.group(3) ? matcher.group(3).toInteger() : 0,
+                    matcher.group(4) ? matcher.group(4).toInteger() : 0,
+            )
         } else {
             throw new ParseException("Could not parse version string '${versionString}'", 0)
         }
@@ -238,64 +135,6 @@ class Version implements Comparable<Version> {
         return 0
     }
 
-    /** The compatibility-level is the lowest VersionLevel (order as in the VersionLevel enum; with MAJOR first (low)
-     *  and REVISION last (high)) two compared versions need to be identical in, to be considered compatible.
-     *
-     *  By default, two versions are compatible, if they only differ in the REVISION. The default compatibility-level
-     *  is therefore VersionLevel.PATCH. For instance, by default the versions 1.1.1-0 and 1.1.1-1 are considered
-     *  compatible, but 1.1.2-0 is not compatible to the first two. If the compatibility level for the comparisons is
-     *  set to null, then all versions are compatible.
-     *
-     *  The second way to declare compatibility is by explicitly declaring compatibility intervals. If there is any
-     *  interval that contains both versions (this and the other) then the two versions are compatible. Also these
-     *  checks account for implicit compatibility defined by the compatibility level. Note that, if two versions are
-     *  compatible then all intermediate versions are also compatible. Therefore, compatibility generates an equivalence
-     *  relation on versions (reflexive, symmetric, transitive).
-     */
-
-    /** This is used to ensure transitivity of compatibility */
-    @CompileStatic(TypeCheckingMode.SKIP)
-    private Collection<VersionInterval> mergeOverlappingIntervals(final Collection<VersionInterval> intervals, VersionLevel level = defaultCompatibilityLevel) {
-        return intervals.toSorted().inject(new LinkedList<VersionInterval>()) { List<VersionInterval> result, VersionInterval next ->
-            if (result.isEmpty()) {
-                [next]
-            } else {
-                def merged = result.first().merge(next, level)
-                if (merged.isPresent()) {
-                    result.drop(1)
-                    result.add(0, merged.get())
-                } else {
-                    result.add(0, next)
-                }
-                result
-            }
-        }
-    }
-
-    /**
-     *
-     * @param other
-     * @param compatibilities   List of compatibility intervals. Will be curated into equivalence classes.
-     * @param level             Compatibility level used for implicit compatibilities. By default REVISIONs are
-     *                          compatible. A value of "null" serves to let all versions be compatible.
-     * @return
-     */
-    boolean compatibleTo(final Version other, final Collection<VersionInterval> compatibilities, VersionLevel level = defaultCompatibilityLevel) {
-        if (null == level) {
-            return true
-        }
-        def mergeCompatibilities = mergeOverlappingIntervals(compatibilities, level)
-        Boolean sameCompatibilityLevel = this.compareTo(other, level) == 0
-        if (sameCompatibilityLevel) {
-            return true
-        } else {
-            VersionInterval sharedInterval = mergeCompatibilities.find { interval ->
-                interval.contains(this, level) && interval.contains(other, level)
-            }
-            return null != sharedInterval
-        }
-    }
-
-
 }
+
 

--- a/src/main/groovy/de/dkfz/roddy/tools/versions/VersionInterval.groovy
+++ b/src/main/groovy/de/dkfz/roddy/tools/versions/VersionInterval.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
+package de.dkfz.roddy.tools.versions
+
+import groovy.transform.CompileStatic
+
+/**
+ * VersionInterval allow to check whether a Version is within the interval. To simplify the implementation of
+ * version compatibility given a set of compatibility intervals as equivalence class (in particular with respect
+ * to transitivity) version interval are Comparable and can be merged (when overlapping).
+ */
+@CompileStatic
+class VersionInterval implements Comparable<VersionInterval> {
+    protected static final VersionLevel defaultCompatibilityLevel = VersionLevel.PATCH
+    final Version from
+    final Version to
+
+    VersionInterval(Version from, Version to) {
+        if (from <= to) {
+            this.from = from
+            this.to = to
+        } else {
+            this.to = from
+            this.from = to
+        }
+    }
+
+    boolean contains(final Version query, VersionLevel level = defaultCompatibilityLevel) {
+        return this.from.compareTo(query, level) <= 0 &&
+                this.to.compareTo(query, level) >= 0
+    }
+
+    boolean overlaps(VersionInterval other, VersionLevel level = defaultCompatibilityLevel) {
+        /** Relations can be partial overlap, containment of one in the other and disjunction. */
+        return this.contains(other.from, level) || this.contains(other.to, level) ||
+                other.contains(this.from, level) || other.contains(this.to, level)
+    }
+
+    /** Lexicographic ordering of VersionIntervals. */
+    @Override
+    int compareTo(VersionInterval o) {
+        return compareTo(o, defaultCompatibilityLevel)
+    }
+    int compareTo(VersionInterval other, VersionLevel level) {
+        return this.from.compareTo(other.from, level) ?: this.to.compareTo(other.to, level)
+    }
+
+    /** Attempt to merge two interval, if they overlap. Otherwise return Optional.empty(). */
+    Optional<VersionInterval> merge(VersionInterval other, VersionLevel level = defaultCompatibilityLevel) {
+        if (this.overlaps(other, level)) {
+            return Optional.of(new VersionInterval([this.from, other.from].min(), [this.to, other.to].max()))
+        } else {
+            return Optional.empty()
+        }
+    }
+
+    @Override
+    String toString() {
+        "[${this.from}, ${this.to}]"
+    }
+}

--- a/src/main/groovy/de/dkfz/roddy/tools/versions/VersionLevel.groovy
+++ b/src/main/groovy/de/dkfz/roddy/tools/versions/VersionLevel.groovy
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
+package de.dkfz.roddy.tools.versions
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+enum VersionLevel {
+    MAJOR,
+    MINOR,
+    PATCH,
+    REVISION;
+
+    static VersionLevel fromInteger(int x) {
+        switch(x) {
+            case 0:
+                return MAJOR;
+            case 1:
+                return MINOR;
+            case 2:
+                return PATCH;
+            case 3:
+                return REVISION;
+            default:
+                throw new NumberFormatException("Cannot interpret integer ${x} as VersionLevel")
+        }
+    }
+
+    /** With the next() and previous() methods VersionLevel can be used in Groovy range expression alla
+     *  PATCH..REVISION. Taken from https://kousenit.org/2008/03/19/turning-java-enums-into-groovy-ranges
+     */
+    VersionLevel next() {
+        VersionLevel[] vals = values()
+        return vals[(this.ordinal() + 1) % vals.length]
+    }
+
+    VersionLevel previous() {
+        VersionLevel[] vals = values()
+        return vals[(this.ordinal() - 1 + vals.length) % vals.length]
+    }
+}
+

--- a/src/test/groovy/de/dkfz/roddy/tools/versions/CompatibilityCheckerSpec.groovy
+++ b/src/test/groovy/de/dkfz/roddy/tools/versions/CompatibilityCheckerSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
+package de.dkfz.roddy.tools.versions
+
+import spock.lang.Specification
+
+class CompatibilityCheckerSpec extends Specification {
+
+    def "version compatibility with ranges" (major1, minor1, patch1, revision1,
+                                             major2, minor2, patch2, revision2,
+                                             compatible) {
+        when:
+        def ranges = [
+                new VersionInterval(new Version(0, 0, 0, 0), new Version(1, 0, 0, 0,)),
+                new VersionInterval(new Version(1, 1, 0, 1), new Version(1, 1, 0, 10)),
+                new VersionInterval(new Version(1, 1, 0, 10), new Version(1, 2, 0, 0)),
+                new VersionInterval(new Version(1,2,0, 0), new Version(1,3,0,0)),
+                new VersionInterval(new Version(1,3,0, 100), new Version(1,4,0,0))
+        ]
+        def version1 = new Version(major1, minor1, patch1, revision1)
+        def version2 = new Version(major2, minor2, patch2, revision2)
+
+        then:
+        CompatibilityChecker.compatibleTo(version1, version2, ranges, VersionLevel.PATCH) == compatible
+
+        where:
+        major1 | minor1 | patch1 | revision1 | major2 | minor2 | patch2 | revision2 | compatible
+        1 |      0 |      0 |         0 |      1 |      0 |      1 |         0 |      false  // inside/outside first interval
+        0 |      0 |      0 |         0 |      1 |      1 |      0 |         1 |      false  // from first and second interval
+        1 |      1 |      0 |         9 |      1 |      1 |      0 |        11 |       true  // from second and third interval but same patch level
+        1 |      3 |      3 |         0 |      1 |      3 |      3 |       100 |       true  // outside intervals but same patch level
+        1 |      1 |      0 |       100 |      1 |      1 |    100 |      1000 |       true  // different patch but same interval
+        1 |      1 |      0 |         1 |      1 |      3 |      0 |         0 |       true  // transitive across overlapping intervals
+        1 |      1 |      0 |         1 |      1 |      4 |      0 |         0 |       true  // transitive across multiple intervals including revision gap-bridging
+
+    }
+
+    def "test backwards compatibility without ranges" (String version1, String version2, VersionLevel level, Boolean compatible) {
+        expect:
+        CompatibilityChecker.isBackwardsCompatibleTo(
+                Version.fromString(version1),
+                Version.fromString(version2),
+                level) == compatible
+
+        where:
+        version1  | version2  | level                 | compatible
+        "3.0.0-0" | "3.0.0-0" | VersionLevel.REVISION | true
+        "2.0.0-0" | "3.0.0-0" | VersionLevel.REVISION | false
+        "3.0.0-1" | "3.0.0-0" | VersionLevel.REVISION | true
+        "3.0.0-2" | "3.0.0-0" | VersionLevel.REVISION | true
+        "3.0.0-1" | "3.0.0-0" | VersionLevel.REVISION | true
+        "3.0.0-0" | "3.0.0-1" | VersionLevel.REVISION | false
+        "3.0.1-0" | "3.0.0-0" | VersionLevel.MINOR    | true
+        "3.1.0-0" | "3.0.0-0" | VersionLevel.MINOR    | true
+        "3.1.0-0" | "4.0.0-0" | VersionLevel.MINOR    | false
+        "3.0.0-0" | "3.1.0-0" | VersionLevel.MINOR    | false
+        "3.1.0-0" | "3.0.100-1000" | VersionLevel.MINOR    | true
+
+    }
+
+
+}

--- a/src/test/groovy/de/dkfz/roddy/tools/versions/VersionIntervalSpec.groovy
+++ b/src/test/groovy/de/dkfz/roddy/tools/versions/VersionIntervalSpec.groovy
@@ -23,10 +23,10 @@ class VersionIntervalSpec extends Specification  {
 
         // At default VersionLevel.
         interval.contains(new Version(1, 1, 0, 0))
-        interval.contains(new Version(1, 2,0,11))
+        interval.contains(new Version(1, 2, 0, 11))
 
         !interval.contains(new Version(1, 0, 0, 0))
-        !interval.contains(new Version(1, 2,1,0))
+        !interval.contains(new Version(1, 2, 1, 0))
 
     }
 

--- a/src/test/groovy/de/dkfz/roddy/tools/versions/VersionIntervalSpec.groovy
+++ b/src/test/groovy/de/dkfz/roddy/tools/versions/VersionIntervalSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
+package de.dkfz.roddy.tools.versions
+
+import spock.lang.Specification
+
+class VersionIntervalSpec extends Specification  {
+
+    def "version-interval containment" () {
+        when:
+        def interval = new VersionInterval(new Version(1, 1, 0, 1), new Version(1, 2, 0, 10))
+
+        then:
+        // At maximal precision VersionLevel
+        interval.contains(new Version(1, 1, 0, 1), VersionLevel.REVISION)
+        interval.contains(new Version(1, 2, 0, 10), VersionLevel.REVISION)
+
+        !interval.contains(new Version(1, 1, 0, 0), VersionLevel.REVISION)
+        !interval.contains(new Version(1, 2, 0, 11), VersionLevel.REVISION)
+
+        // At default VersionLevel.
+        interval.contains(new Version(1, 1, 0, 0))
+        interval.contains(new Version(1, 2,0,11))
+
+        !interval.contains(new Version(1, 0, 0, 0))
+        !interval.contains(new Version(1, 2,1,0))
+
+    }
+
+    def "version interval-interval overlaps" () {
+        given:
+        def i1 = new VersionInterval(Version.fromString("1.0.0-0"), Version.fromString("1.0.0-0"))
+        def i2 = new VersionInterval(Version.fromString("1.0.0-1"), Version.fromString("1.1.0-0"))
+        def i3 = new VersionInterval(Version.fromString("1.1.0-0"), Version.fromString("1.2.0-0"))
+        def i4 = new VersionInterval(Version.fromString("1.2.1-0"), Version.fromString("1.3.0-0"))
+        expect:
+        i1.overlaps(i2)
+        !i1.overlaps(i2, VersionLevel.REVISION)
+        i2.overlaps(i3, VersionLevel.REVISION)
+        !i3.overlaps(i4, VersionLevel.PATCH)
+        i3.overlaps(i4, VersionLevel.MINOR)
+    }
+
+}

--- a/src/test/groovy/de/dkfz/roddy/tools/versions/VersionLevelSpec.groovy
+++ b/src/test/groovy/de/dkfz/roddy/tools/versions/VersionLevelSpec.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018 German Cancer Research Center (DKFZ).
+ *
+ * Distributed under the MIT License (license terms are at https://www.github.com/eilslabs/Roddy/LICENSE.txt).
+ */
+package de.dkfz.roddy.tools.versions
+
+import spock.lang.Specification
+
+class VersionLevelSpec extends Specification {
+
+    def "version-level toString"() {
+        when:
+        def version = new Version(1,2,3,4)
+        then:
+        version.toString() == "1.2.3-4"
+        version.toString(VersionLevel.REVISION) == "1.2.3-4"
+        version.toString(VersionLevel.PATCH) == "1.2.3"
+        version.toString(VersionLevel.MINOR) == "1.2"
+        version.toString(VersionLevel.MAJOR) == "1"
+    }
+
+
+}

--- a/src/test/groovy/de/dkfz/roddy/tools/versions/VersionSpec.groovy
+++ b/src/test/groovy/de/dkfz/roddy/tools/versions/VersionSpec.groovy
@@ -29,6 +29,21 @@ class VersionSpec extends Specification {
         final ParseException e2 = thrown()
     }
 
+
+    def "construct version from partial version string" (String theString, String theParseResult) {
+        expect:
+        Version.fromString(theString).toString() == theParseResult
+
+        where:
+        theString | theParseResult
+        "1"       | "1.0.0-0"
+        "1.2"     | "1.2.0-0"
+        "1.2.3"   | "1.2.3-0"
+        "1.2.3-4" | "1.2.3-4"
+    }
+
+
+
     def "increasing the major number" () {
         when:
         Version version = new Version (1, 2, 3, 4)
@@ -77,90 +92,15 @@ class VersionSpec extends Specification {
         when:
         Version version = new Version (12, 11, 10, 9)
         then:
-        version[Version.VersionLevel.MAJOR] == 12
-        version[Version.VersionLevel.MINOR] == 11
-        version[Version.VersionLevel.PATCH] == 10
-        version[Version.VersionLevel.REVISION] == 9
+        version[VersionLevel.MAJOR] == 12
+        version[VersionLevel.MINOR] == 11
+        version[VersionLevel.PATCH] == 10
+        version[VersionLevel.REVISION] == 9
         def (major, minor, patch, revision) = version
         major == 12
         minor == 11
         patch == 10
         revision == 9
-    }
-
-    def "version-interval containment" () {
-        when:
-        def interval = new VersionInterval(new Version(1, 1, 0, 1), new Version(1, 2, 0, 10))
-
-        then:
-        // At maximal precision VersionLevel
-        interval.contains(new Version(1, 1, 0, 1), Version.VersionLevel.REVISION)
-        interval.contains(new Version(1, 2, 0, 10), Version.VersionLevel.REVISION)
-
-        !interval.contains(new Version(1, 1, 0, 0), Version.VersionLevel.REVISION)
-        !interval.contains(new Version(1, 2, 0, 11), Version.VersionLevel.REVISION)
-
-        // At default VersionLevel.
-        interval.contains(new Version(1, 1, 0, 0))
-        interval.contains(new Version(1, 2,0,11))
-
-        !interval.contains(new Version(1, 0, 0, 0))
-        !interval.contains(new Version(1, 2,1,0))
-
-    }
-
-    def "version interval-interval overlaps" () {
-        given:
-        def i1 = new VersionInterval(Version.fromString("1.0.0-0"), Version.fromString("1.0.0-0"))
-        def i2 = new VersionInterval(Version.fromString("1.0.0-1"), Version.fromString("1.1.0-0"))
-        def i3 = new VersionInterval(Version.fromString("1.1.0-0"), Version.fromString("1.2.0-0"))
-        def i4 = new VersionInterval(Version.fromString("1.2.1-0"), Version.fromString("1.3.0-0"))
-        expect:
-        i1.overlaps(i2)
-        !i1.overlaps(i2, Version.VersionLevel.REVISION)
-        i2.overlaps(i3, Version.VersionLevel.REVISION)
-        !i3.overlaps(i4, Version.VersionLevel.PATCH)
-        i3.overlaps(i4, Version.VersionLevel.MINOR)
-    }
-
-    def "version compatibility" (major1, minor1, patch1, revision1,
-                                 major2, minor2, patch2, revision2,
-                                 compatible) {
-        when:
-        def ranges = [
-                new VersionInterval(new Version(0, 0, 0, 0), new Version(1, 0, 0, 0,)),
-                new VersionInterval(new Version(1, 1, 0, 1), new Version(1, 1, 0, 10)),
-                new VersionInterval(new Version(1, 1, 0, 10), new Version(1, 2, 0, 0)),
-                new VersionInterval(new Version(1,2,0, 0), new Version(1,3,0,0)),
-                new VersionInterval(new Version(1,3,0, 100), new Version(1,4,0,0))
-        ]
-        def version1 = new Version(major1, minor1, patch1, revision1)
-        def version2 = new Version(major2, minor2, patch2, revision2)
-
-        then:
-        version1.compatibleTo(version2, ranges) == compatible
-
-        where:
-        major1 | minor1 | patch1 | revision1 | major2 | minor2 | patch2 | revision2 | compatible
-             1 |      0 |      0 |         0 |      1 |      0 |      1 |         0 |      false  // inside/outside first interval
-             0 |      0 |      0 |         0 |      1 |      1 |      0 |         1 |      false  // from first and second interval
-             1 |      1 |      0 |         9 |      1 |      1 |      0 |        11 |       true  // from second and third interval but same patch level
-             1 |      3 |      3 |         0 |      1 |      3 |      3 |       100 |       true  // outside intervals but same patch level
-             1 |      1 |      0 |       100 |      1 |      1 |    100 |      1000 |       true  // different patch but same interval
-             1 |      1 |      0 |         1 |      1 |      3 |      0 |         0 |       true  // transitive across overlapping intervals
-             1 |      1 |      0 |         1 |      1 |      4 |      0 |         0 |       true  // transitive across multiple intervals including revision gap-bridging
-
-    }
-
-    def "version-level toString"() {
-        when:
-        def version = new Version(1,2,3,4)
-        then:
-        version.toString() == "1.2.3-4"
-        version.toString(Version.VersionLevel.REVISION) == "1.2.3-4"
-        version.toString(Version.VersionLevel.PATCH) == "1.2.3"
-        version.toString(Version.VersionLevel.MINOR) == "1.2"
-        version.toString(Version.VersionLevel.MAJOR) == "1"
     }
 
 }


### PR DESCRIPTION
…ty checker was added. Changed group in build.gradle to fix composite build feature in IDE.

@dankwart-de: This may actually be a API breaking change (=> 2.0.0!). I am not aware of any users, though -- even we did not use the version code up till now. Finally, it may still not be complete (maybe we also want to be able to model say beta releases or `develop`?) 

So, should we increase to 0.0.5 with the PR or 0.1.0? As long as we are unstable, we may loosen the semantic versioning constraint.