### PR TITLE
Add the DateTimeHelper class, add a method to IOHelperMethods.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,3 +71,18 @@ jar {
         from "$buildDir/pom.xml"
     }
 }
+
+test {
+    workingDir = System.getProperty("user.dir")
+    ignoreFailures = project.hasProperty("ignoreFailedTests")
+
+    testLogging {
+        debug {
+            events "started", "skipped", "failed"
+            exceptionFormat "full"
+        }
+        events "failed"
+        exceptionFormat "full"
+        setShowStandardStreams true
+    }
+}

--- a/src/main/groovy/de/dkfz/roddy/tools/DateTimeHelper.groovy
+++ b/src/main/groovy/de/dkfz/roddy/tools/DateTimeHelper.groovy
@@ -1,0 +1,56 @@
+package de.dkfz.roddy.tools
+
+import groovy.transform.CompileStatic
+
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+@CompileStatic
+class DateTimeHelper {
+
+    private final DateTimeFormatter DATE_PATTERN
+
+    DateTimeHelper(String dateParserPatternPattern = null, ZoneId timeZoneId = ZoneId.systemDefault()) {
+        if (!dateParserPatternPattern)
+            DATE_PATTERN = DateTimeFormatter.ISO_DATE_TIME
+        else
+            this.DATE_PATTERN = DateTimeFormatter
+                    .ofPattern(dateParserPatternPattern)
+                    .withLocale(Locale.ENGLISH)
+                    .withZone(timeZoneId ?: ZoneId.systemDefault())
+    }
+
+    DateTimeFormatter getDatePattern() {
+        return DATE_PATTERN
+    }
+
+    ZonedDateTime parseTime(String str) {
+        ZonedDateTime date = ZonedDateTime.parse(str, DATE_PATTERN)
+        return date
+    }
+
+    static Duration toDuration(LocalDateTime ldt) {
+        // There is no plusYears, we just assume 365 days for a year
+        Duration.ofSeconds(ldt.second).plusMinutes(ldt.minute).plusHours(ldt.hour).plusDays(ldt.dayOfYear + ldt.year * 365)
+    }
+    
+    static Duration toDuration(int years, int days, int hours, int minutes, int seconds) {
+        Duration.ofSeconds(seconds).plusMinutes(minutes).plusHours(hours).plusDays(days + years * 365)
+    }
+
+    static Duration timeSpanOf(LocalDateTime lower, LocalDateTime higher) {
+        toDuration(higher) - toDuration(lower)
+    }
+
+    static boolean isOlderThan(Duration age, int days, int hours, int minutes, int seconds) {
+        Duration maxAge = toDuration(0, days, hours, minutes, seconds)
+        return isOlderThan(age, maxAge)
+    }
+
+    static boolean isOlderThan(Duration timeSpan, Duration maxAge) {
+        (maxAge - timeSpan).isNegative()
+    }
+}

--- a/src/main/groovy/de/dkfz/roddy/tools/DateTimeHelper.groovy
+++ b/src/main/groovy/de/dkfz/roddy/tools/DateTimeHelper.groovy
@@ -13,12 +13,12 @@ class DateTimeHelper {
 
     private final DateTimeFormatter DATE_PATTERN
 
-    DateTimeHelper(String dateParserPatternPattern = null, Locale locale = Locale.default, ZoneId timeZoneId = ZoneId.systemDefault()) {
-        if (!dateParserPatternPattern)
+    DateTimeHelper(String dateParserPattern = null, Locale locale = Locale.default, ZoneId timeZoneId = ZoneId.systemDefault()) {
+        if (!dateParserPattern)
             DATE_PATTERN = DateTimeFormatter.ISO_DATE_TIME
         else
             this.DATE_PATTERN = DateTimeFormatter
-                    .ofPattern(dateParserPatternPattern)
+                    .ofPattern(dateParserPattern)
                     .withLocale(locale)
                     .withZone(timeZoneId ?: ZoneId.systemDefault())
     }

--- a/src/main/groovy/de/dkfz/roddy/tools/DateTimeHelper.groovy
+++ b/src/main/groovy/de/dkfz/roddy/tools/DateTimeHelper.groovy
@@ -13,13 +13,13 @@ class DateTimeHelper {
 
     private final DateTimeFormatter DATE_PATTERN
 
-    DateTimeHelper(String dateParserPatternPattern = null, ZoneId timeZoneId = ZoneId.systemDefault()) {
+    DateTimeHelper(String dateParserPatternPattern = null, Locale locale = Locale.default, ZoneId timeZoneId = ZoneId.systemDefault()) {
         if (!dateParserPatternPattern)
             DATE_PATTERN = DateTimeFormatter.ISO_DATE_TIME
         else
             this.DATE_PATTERN = DateTimeFormatter
                     .ofPattern(dateParserPatternPattern)
-                    .withLocale(Locale.ENGLISH)
+                    .withLocale(locale)
                     .withZone(timeZoneId ?: ZoneId.systemDefault())
     }
 
@@ -27,30 +27,19 @@ class DateTimeHelper {
         return DATE_PATTERN
     }
 
-    ZonedDateTime parseTime(String str) {
+    ZonedDateTime parseToZonedDateTime(String str) {
         ZonedDateTime date = ZonedDateTime.parse(str, DATE_PATTERN)
         return date
     }
 
-    static Duration toDuration(LocalDateTime ldt) {
-        // There is no plusYears, we just assume 365 days for a year
-        Duration.ofSeconds(ldt.second).plusMinutes(ldt.minute).plusHours(ldt.hour).plusDays(ldt.dayOfYear + ldt.year * 365)
-    }
-    
-    static Duration toDuration(int years, int days, int hours, int minutes, int seconds) {
-        Duration.ofSeconds(seconds).plusMinutes(minutes).plusHours(hours).plusDays(days + years * 365)
+    static Duration differenceBetween(LocalDateTime a, LocalDateTime b) {
+        Duration result = Duration.between(a, b)
+        if (result.isNegative())
+            result = result.multipliedBy(-1)
+        result
     }
 
-    static Duration timeSpanOf(LocalDateTime lower, LocalDateTime higher) {
-        toDuration(higher) - toDuration(lower)
-    }
-
-    static boolean isOlderThan(Duration age, int days, int hours, int minutes, int seconds) {
-        Duration maxAge = toDuration(0, days, hours, minutes, seconds)
-        return isOlderThan(age, maxAge)
-    }
-
-    static boolean isOlderThan(Duration timeSpan, Duration maxAge) {
-        (maxAge - timeSpan).isNegative()
+    static boolean durationExceeds(Duration duration, Duration maximum) {
+        (maximum - duration).isNegative()
     }
 }

--- a/src/main/groovy/de/dkfz/roddy/tools/RoddyIOHelperMethods.groovy
+++ b/src/main/groovy/de/dkfz/roddy/tools/RoddyIOHelperMethods.groovy
@@ -17,8 +17,6 @@ import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.PosixFileAttributeView
 import java.nio.file.attribute.PosixFilePermissions
 
-import static de.dkfz.roddy.tools.shell.bash.Service.escape
-
 /**
  * Contains methods which print out text on the console, like listworkflows.
  * This is a bit easier in groovy so we'll use it for these tasks.
@@ -358,21 +356,32 @@ class RoddyIOHelperMethods {
         return Optional.empty()
     }
 
-
+    /**
+     * Print out the difference of nanosecond measurements (long, System.nanotime()) in a human readable way with a
+     * message and in milli seconds.
+     * @param info
+     * @param t1
+     * @param t2
+     * @return
+     */
     static String printTimingInfo(String info, long t1, long t2) {
         return "Timing " + info + ": " + ((t2 - t1) / 1000000) + " ms"
     }
 
     /**
      * Will format a map to a two column table. The width of the first column will be calculated using the length of the
-     * longest element.
-     * @param map
-     * @param cntOfTabs
-     * @param tabSep
-     * @param closureForValue
+     * longest element. This methods output is not intended to be parsed but to be human readable.
+     *
+     * Can be used like:
+     * convert...Table(aMapWithFiles, 1, " : ", { File v -> v.absolutePath }
+     *
+     * @param map A map with objects (File in the example)
+     * @param cntOfTabs Number of tabs in front of each line
+     * @param tabSep Sign for the separator
+     * @param closureForValue Is used to select something to print from the objects in the map
      * @return
      */
-    static List<String> convertMapToTwoColumnsFormattedTable(Map<String, ?> map, int cntOfTabs, String tabSep, Closure closureForValue) {
+    static List<String> convertMapToTwoColumnsPrettyTable(Map<String, ?> map, int cntOfTabs, String tabSep, Closure closureForValue) {
         final int keyWidth = map.keySet().collect { it.size() }.max()
         map.collect {
             def k, def v ->

--- a/src/main/groovy/de/dkfz/roddy/tools/RoddyIOHelperMethods.groovy
+++ b/src/main/groovy/de/dkfz/roddy/tools/RoddyIOHelperMethods.groovy
@@ -362,4 +362,21 @@ class RoddyIOHelperMethods {
     static String printTimingInfo(String info, long t1, long t2) {
         return "Timing " + info + ": " + ((t2 - t1) / 1000000) + " ms"
     }
+
+    /**
+     * Will format a map to a two column table. The width of the first column will be calculated using the length of the
+     * longest element.
+     * @param map
+     * @param cntOfTabs
+     * @param tabSep
+     * @param closureForValue
+     * @return
+     */
+    static List<String> convertMapToTwoColumnsFormattedTable(Map<String, ?> map, int cntOfTabs, String tabSep, Closure closureForValue) {
+        final int keyWidth = map.keySet().collect { it.size() }.max()
+        map.collect {
+            def k, def v ->
+                ("\t" * cntOfTabs) + k.toString().padRight(keyWidth) + tabSep + closureForValue(v)
+        }
+    }
 }

--- a/src/test/groovy/de/dkfz/roddy/tools/DateTimeHelperTest.groovy
+++ b/src/test/groovy/de/dkfz/roddy/tools/DateTimeHelperTest.groovy
@@ -1,0 +1,107 @@
+package de.dkfz.roddy.tools
+
+import groovy.transform.CompileStatic
+import spock.lang.Ignore
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeParseException
+
+import static de.dkfz.roddy.tools.DateTimeHelper.toDuration
+
+class DateTimeHelperTest extends Specification {
+
+    @CompileStatic
+    static LocalDateTime localDateTime(List<Integer> numbers) {
+        LocalDateTime.of(numbers[0], numbers[1], numbers[2], numbers[3], numbers[4])
+    }
+
+    def "Construct object"(parserPattern, zoneId, expectedZone) {
+        expect:
+        (new DateTimeHelper(parserPattern, zoneId)).datePattern.zone == expectedZone
+
+        where: // I do not know how to test this properly. We can test for the zoneId, but not for the pattern
+        parserPattern        | zoneId                 | expectedZone
+        null                 | null                   | null
+        null                 | ZoneId.of("Asia/Aden") | null
+        "MMM ppd HH:mm yyyy" | null                   | ZoneId.systemDefault()
+        "MMM ppd HH:mm yyyy" | ZoneId.systemDefault() | ZoneId.systemDefault()
+        "MMM ppd HH:mm yyyy" | ZoneId.of("Asia/Aden") | ZoneId.of("Asia/Aden")
+    }
+
+    def "ParseTime"(parserPattern, timeString, expectedResult) {
+        expect:
+        new DateTimeHelper(parserPattern).parseTime(timeString) == expectedResult
+
+        where:
+        parserPattern        | timeString                                 | expectedResult
+        null                 | "2011-12-03T10:15:30+01:00[Europe/Berlin]" | ZonedDateTime.of(2011, 12, 3, 10, 15, 30, 0, ZoneId.systemDefault())
+        "MMM ppd HH:mm yyyy" | "Jan  7 10:00 2000"                        | ZonedDateTime.of(2000, 1, 7, 10, 0, 0, 0, ZoneId.systemDefault())
+    }
+
+    def "ParseTimeWithException"() {
+        when:
+        new DateTimeHelper(null).parseTime("abcinvalid")
+
+        then:
+        thrown(DateTimeParseException)
+    }
+
+    def "To Duration from DateTime"(timeArray, expectedDays) {
+        given:
+        def ldt = localDateTime(timeArray)
+        def duration = toDuration(ldt)
+
+        expect:
+        duration.toDays() == expectedDays
+
+        where:
+        timeArray            | expectedDays
+        [2000, 1, 1, 0, 0]   | 2000 * 365 + 1
+        [2000, 2, 10, 12, 0] | 2000 * 365 + 31 + 10
+    }
+
+    def "To Duration from values"(years, days, hours, minutes, seconds, expectedDays, expectedMinutes) {
+        given:
+        def duration = toDuration(years, days, hours, minutes, seconds)
+
+        expect:
+        duration.toDays() == expectedDays
+        duration.toMinutes() == expectedMinutes
+
+        where:
+        years | days | hours | minutes | seconds | expectedDays   | expectedMinutes
+        2000  | 1    | 1     | 0       | 0       | 2000 * 365 + 1 | expectedDays * 24 * 60 + 60
+        2000  | 2    | 10    | 12      | 0       | 2000 * 365 + 2 | expectedDays * 24 * 60 + 600 + 12
+    }
+
+    def "TimeSpanCalc"(lower, higher, expected) {
+        given:
+        def ldt = localDateTime(lower)
+        def ldh = localDateTime(higher)
+        def timeSpan = DateTimeHelper.timeSpanOf(ldt, ldh)
+
+        expect:
+        timeSpan == expected
+
+        where:
+        lower                | higher                | expected
+        [2000, 2, 10, 12, 0] | [2000, 2, 11, 12, 0]  | toDuration(0, 1, 0, 0, 0)
+        [2000, 1, 5, 5, 0]   | [2000, 4, 10, 12, 10] | toDuration(0, 26 + 29 + 31 + 10, 7, 10, 0)
+    }
+
+    def "IsOlderThan"(age, maxAge, result) {
+        expect:
+        DateTimeHelper.isOlderThan(age, maxAge) == result
+
+        where:
+        age                       | maxAge                    | result
+        toDuration(0, 2, 0, 0, 0) | toDuration(0, 2, 1, 0, 0) | false
+        toDuration(0, 2, 0, 0, 0) | toDuration(0, 1, 1, 0, 0) | true
+
+    }
+}

--- a/src/test/groovy/de/dkfz/roddy/tools/DateTimeHelperTest.groovy
+++ b/src/test/groovy/de/dkfz/roddy/tools/DateTimeHelperTest.groovy
@@ -35,7 +35,7 @@ class DateTimeHelperTest extends Specification {
 
         where:
         parserPattern        | locale         | timeString                                 | expectedResult
-        null                 | Locale.ENGLISH | "2011-12-03T10:15:30+01:00[Europe/Berlin]" | ZonedDateTime.of(2011, 12, 3, 10, 15, 30, 0, ZoneId.systemDefault())
+        null                 | Locale.ENGLISH | "2011-12-03T10:15:30+01:00[Europe/Berlin]" | ZonedDateTime.of(2011, 12, 3, 10, 15, 30, 0, ZoneId.of("Europe/Berlin"))
         "MMM ppd HH:mm yyyy" | Locale.ENGLISH | "Jan  7 10:00 2000"                        | ZonedDateTime.of(2000, 1, 7, 10, 0, 0, 0, ZoneId.systemDefault())
         "MMM ppd HH:mm yyyy" | Locale.ENGLISH | "Dec 28 19:56 2000"                        | ZonedDateTime.of(2000, 12, 28, 19, 56, 0, 0, ZoneId.systemDefault())
         "MMM ppd HH:mm yyyy" | Locale.GERMAN  | "Dez 28 19:57 2000"                        | ZonedDateTime.of(2000, 12, 28, 19, 57, 0, 0, ZoneId.systemDefault())

--- a/src/test/groovy/de/dkfz/roddy/tools/DateTimeHelperTest.groovy
+++ b/src/test/groovy/de/dkfz/roddy/tools/DateTimeHelperTest.groovy
@@ -1,8 +1,6 @@
 package de.dkfz.roddy.tools
 
 import groovy.transform.CompileStatic
-import spock.lang.Ignore
-import spock.lang.Shared
 import spock.lang.Specification
 
 import java.time.Duration
@@ -11,8 +9,6 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeParseException
 
-import static de.dkfz.roddy.tools.DateTimeHelper.toDuration
-
 class DateTimeHelperTest extends Specification {
 
     @CompileStatic
@@ -20,88 +16,66 @@ class DateTimeHelperTest extends Specification {
         LocalDateTime.of(numbers[0], numbers[1], numbers[2], numbers[3], numbers[4])
     }
 
-    def "Construct object"(parserPattern, zoneId, expectedZone) {
+    def "Construct object"(parserPattern, locale, zoneId, expectedZone) {
         expect:
-        (new DateTimeHelper(parserPattern, zoneId)).datePattern.zone == expectedZone
+        (new DateTimeHelper(parserPattern, locale, zoneId)).datePattern.zone == expectedZone
 
         where: // I do not know how to test this properly. We can test for the zoneId, but not for the pattern
-        parserPattern        | zoneId                 | expectedZone
-        null                 | null                   | null
-        null                 | ZoneId.of("Asia/Aden") | null
-        "MMM ppd HH:mm yyyy" | null                   | ZoneId.systemDefault()
-        "MMM ppd HH:mm yyyy" | ZoneId.systemDefault() | ZoneId.systemDefault()
-        "MMM ppd HH:mm yyyy" | ZoneId.of("Asia/Aden") | ZoneId.of("Asia/Aden")
+        parserPattern        | locale         | zoneId                 | expectedZone
+        null                 | Locale.ENGLISH | null                   | null
+        null                 | Locale.ENGLISH | ZoneId.of("Asia/Aden") | null
+        "MMM ppd HH:mm yyyy" | Locale.ENGLISH | null                   | ZoneId.systemDefault()
+        "MMM ppd HH:mm yyyy" | Locale.ENGLISH | ZoneId.systemDefault() | ZoneId.systemDefault()
+        "MMM ppd HH:mm yyyy" | Locale.ENGLISH | ZoneId.of("Asia/Aden") | ZoneId.of("Asia/Aden")
     }
 
-    def "ParseTime"(parserPattern, timeString, expectedResult) {
+    def "ParseTime"(parserPattern, locale, timeString, expectedResult) {
         expect:
-        new DateTimeHelper(parserPattern).parseTime(timeString) == expectedResult
+        new DateTimeHelper(parserPattern, locale).parseToZonedDateTime(timeString) == expectedResult
 
         where:
-        parserPattern        | timeString                                 | expectedResult
-        null                 | "2011-12-03T10:15:30+01:00[Europe/Berlin]" | ZonedDateTime.of(2011, 12, 3, 10, 15, 30, 0, ZoneId.systemDefault())
-        "MMM ppd HH:mm yyyy" | "Jan  7 10:00 2000"                        | ZonedDateTime.of(2000, 1, 7, 10, 0, 0, 0, ZoneId.systemDefault())
+        parserPattern        | locale         | timeString                                 | expectedResult
+        null                 | Locale.ENGLISH | "2011-12-03T10:15:30+01:00[Europe/Berlin]" | ZonedDateTime.of(2011, 12, 3, 10, 15, 30, 0, ZoneId.systemDefault())
+        "MMM ppd HH:mm yyyy" | Locale.ENGLISH | "Jan  7 10:00 2000"                        | ZonedDateTime.of(2000, 1, 7, 10, 0, 0, 0, ZoneId.systemDefault())
+        "MMM ppd HH:mm yyyy" | Locale.ENGLISH | "Dec 28 19:56 2000"                        | ZonedDateTime.of(2000, 12, 28, 19, 56, 0, 0, ZoneId.systemDefault())
+        "MMM ppd HH:mm yyyy" | Locale.GERMAN  | "Dez 28 19:57 2000"                        | ZonedDateTime.of(2000, 12, 28, 19, 57, 0, 0, ZoneId.systemDefault())
     }
 
     def "ParseTimeWithException"() {
         when:
-        new DateTimeHelper(null).parseTime("abcinvalid")
+        new DateTimeHelper(null).parseToZonedDateTime("abcinvalid")
 
         then:
         thrown(DateTimeParseException)
     }
 
-    def "To Duration from DateTime"(timeArray, expectedDays) {
+    def 'Test differenceBetween'(List<Integer> a, List<Integer> b, expected) {
         given:
-        def ldt = localDateTime(timeArray)
-        def duration = toDuration(ldt)
-
-        expect:
-        duration.toDays() == expectedDays
-
-        where:
-        timeArray            | expectedDays
-        [2000, 1, 1, 0, 0]   | 2000 * 365 + 1
-        [2000, 2, 10, 12, 0] | 2000 * 365 + 31 + 10
-    }
-
-    def "To Duration from values"(years, days, hours, minutes, seconds, expectedDays, expectedMinutes) {
-        given:
-        def duration = toDuration(years, days, hours, minutes, seconds)
-
-        expect:
-        duration.toDays() == expectedDays
-        duration.toMinutes() == expectedMinutes
-
-        where:
-        years | days | hours | minutes | seconds | expectedDays   | expectedMinutes
-        2000  | 1    | 1     | 0       | 0       | 2000 * 365 + 1 | expectedDays * 24 * 60 + 60
-        2000  | 2    | 10    | 12      | 0       | 2000 * 365 + 2 | expectedDays * 24 * 60 + 600 + 12
-    }
-
-    def "TimeSpanCalc"(lower, higher, expected) {
-        given:
-        def ldt = localDateTime(lower)
-        def ldh = localDateTime(higher)
-        def timeSpan = DateTimeHelper.timeSpanOf(ldt, ldh)
+        def dta = localDateTime(a)
+        def dtb = localDateTime(b)
+        def timeSpan = DateTimeHelper.differenceBetween(dta, dtb)
 
         expect:
         timeSpan == expected
 
         where:
-        lower                | higher                | expected
-        [2000, 2, 10, 12, 0] | [2000, 2, 11, 12, 0]  | toDuration(0, 1, 0, 0, 0)
-        [2000, 1, 5, 5, 0]   | [2000, 4, 10, 12, 10] | toDuration(0, 26 + 29 + 31 + 10, 7, 10, 0)
+        a                     | b                     | expected
+        [2000, 2, 10, 12, 0]  | [2000, 2, 11, 12, 0]  | Duration.ofDays(1)
+        [2000, 1, 5, 5, 0]    | [2000, 4, 10, 12, 10] | Duration.ofDays(26 + 29 + 31 + 10).plusHours(7).plusMinutes(10)
+        [2000, 4, 10, 12, 10] | [2000, 1, 5, 5, 0]    | Duration.ofDays(26 + 29 + 31 + 10).plusHours(7).plusMinutes(10)
+        [2001, 1, 1, 0, 0]    | [2000, 1, 1, 0, 0]    | Duration.ofDays(366) // Leap year
+        [2100, 1, 1, 0, 0]    | [2000, 1, 1, 0, 0]    | Duration.ofDays(25 * 366 + 75 * 365)
+        [2000, 1, 1, 0, 0]    | [2100, 1, 1, 0, 0]    | Duration.ofDays(25 * 366 + 75 * 365)
     }
 
-    def "IsOlderThan"(age, maxAge, result) {
+    def 'Test durationExceeds'(duration, maxDuration, result) {
         expect:
-        DateTimeHelper.isOlderThan(age, maxAge) == result
+        DateTimeHelper.durationExceeds(duration, maxDuration) == result
 
         where:
-        age                       | maxAge                    | result
-        toDuration(0, 2, 0, 0, 0) | toDuration(0, 2, 1, 0, 0) | false
-        toDuration(0, 2, 0, 0, 0) | toDuration(0, 1, 1, 0, 0) | true
+        duration           | maxDuration                     | result
+        Duration.ofDays(2) | Duration.ofDays(2).plusHours(1) | false
+        Duration.ofDays(2) | Duration.ofDays(1).plusHours(1) | true
 
     }
 }


### PR DESCRIPTION
Add convertMapToTwoColumnsFormattedTable to RoddyIOHelperMethods. This
was taken from one of the Roddy classes and can be used generically.

Add the DateTimeHelper class, which tries to reduces the necessity to
fiddle around with the Joda-Time and the Java time classes:
- By default, the class will parse ISO_DATE_TIME strings but can be
  constructed with different patterns and time zones.
- parseTime will use the pattern in the constructor or the default
  pattern to parse a time string.
- toDuration will convert a LocalDateTime object to a Duration object
  However, this is an approximation, as additional days of leap years
  are not taken into account.
- toDuration can also be used with values for years, days and so on
- timeSpanOf will calculate the duration between two LocalDateTimes
- isOlderThan will tell you, if a Duration is higher than a Duration
  called maxAge. Alternatively, you can also call the method with
  values for days, hours and so on.

Created a test class which covers all methods and the constructor.