### PR TITLE
Async execution result

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ToolLib
 
-[![Build Status - Travis](https://travis-ci.org/eilslabs/RoddyToolLib.svg?branch=develop)](https://travis-ci.org/eilslabs/RoddyToolLib)
+[![Build Status - Travis](https://travis-ci.org/TheRoddyWMS/RoddyToolLib.svg?branch=develop)](https://travis-ci.org/TheRoddyWMS/RoddyToolLib)
 
-Tool library used in [BatchEuphoria](https://github.com/eilslabs/BatchEuphoria) and [Roddy](https://github.com/eilslabs/Roddy).
+Tool library used in [BatchEuphoria](https://github.com/TheRoddyWMS/BatchEuphoria) and [Roddy](https://github.com/TheRoddyWMS/Roddy).
 
 ## Build
 

--- a/RoddyToolLib.iml
+++ b/RoddyToolLib.iml
@@ -9,10 +9,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/out" />
     </content>
-    <orderEntry type="jdk" jdkName="1.8.0_162" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="R User Library" level="project" />
-    <orderEntry type="library" name="R Skeletons" level="application" />
     <orderEntry type="library" name="Gradle: org.codehaus.groovy:groovy-all:2.4.9" level="project" />
   </component>
 </module>

--- a/src/main/groovy/de/dkfz/roddy/execution/io/AsyncExecutionResult.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/io/AsyncExecutionResult.groovy
@@ -1,0 +1,66 @@
+package de.dkfz.roddy.execution.io
+
+import java.util.concurrent.Future
+import java.util.concurrent.CompletableFuture
+
+/** Like ExecutionResult, but taking Futures of the exit code (usually the actual process) and the standard output and
+ *  error streams. Calling any of the methods will block until the process is finished!
+ */
+class AsyncExecutionResult extends ExecutionResult {
+
+    private final Future<Integer> exitCodeF
+    private final Future<List<String>> stdoutF
+    private final Future<List<String>> stderrF
+    private final Future<Boolean> successfulF
+
+    /** The AsyncExecutionResult takes Futures of a number of values. Calling any of the methods of the superclass
+     *  that return the values will block until the result is available.
+     *
+     * @param process
+     * @param stdout
+     * @param stderr
+     * @param successful   Can be a future. By default (when set to null), it will be set success if exitCode == 0.
+     */
+    AsyncExecutionResult(CompletableFuture<Integer> process,
+                         CompletableFuture<List<String>> stdout,
+                         CompletableFuture<List<String>> stderr,
+                         CompletableFuture<Boolean> successful = null) {
+        super(true, 0, [], "") // These are only stub-values.
+        this.exitCodeF = process
+        this.stderrF = stderr
+        this.stdoutF = stdout
+        if (null == successful) {
+            this.successfulF = process.thenApply {exitCode ->
+                exitCode == 0
+            }
+        } else {
+            this.successfulF = successful
+        }
+    }
+
+    @Override
+    int getExitCode() {
+        return exitCodeF.get()
+    }
+
+    @Override
+    List<String> getResultLines() {
+        return stdoutF.get()
+    }
+
+    @Override
+    String getFirstLine() {
+        return stdoutF.get()
+    }
+
+    @Override
+    boolean isSuccessful() {
+        return successfulF.get()
+    }
+
+    @Override
+    boolean getSuccessful() {
+        return successfulF.get()
+    }
+
+}

--- a/src/main/groovy/de/dkfz/roddy/execution/io/AsyncExecutionResult.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/io/AsyncExecutionResult.groovy
@@ -5,6 +5,8 @@ import java.util.concurrent.CompletableFuture
 
 /** Like ExecutionResult, but taking Futures of the exit code (usually the actual process) and the standard output and
  *  error streams. Calling any of the methods will block until the process is finished!
+ *
+ *  TODO Make ExecutionResult and AsyncExecutionResult common subclasses of an IExecutionResult interface.
  */
 class AsyncExecutionResult extends ExecutionResult {
 

--- a/src/main/groovy/de/dkfz/roddy/execution/io/ExecutionResult.java
+++ b/src/main/groovy/de/dkfz/roddy/execution/io/ExecutionResult.java
@@ -20,24 +20,31 @@ public class ExecutionResult extends InfoObject {
     /**
      * This can hold some sort of process id for a process
      */
-    public final String processID;
+    protected final String processID;
 
     /**
      * Successful or not?
      */
-    public final boolean successful;
+    protected final boolean successful;
     /**
      * All result lines.
      */
-    public final List<String> resultLines;
+    protected final List<String> resultLines;
     /**
      * First line of the result array.
      * Null if no entries are in the array.
      */
-    public final String firstLine;
+    protected final String firstLine;
 
-    public final int exitCode;
+    protected final int exitCode;
 
+    /** Contain the results of an execution. Note that the usage of this class is quite inconsistent.
+     *
+     * @param successful   Whether the execution was successful. Some tools have exit code == 0 but are yet not successful.
+     * @param exitCode     The actual exit code. (Warning: Often this is zero, because waitFor == false).
+     * @param resultLines  This should be the standard output and error (interleaved). (Warning: Often this is only stdout).
+     * @param processID    The process ID, if available.
+     */
     public ExecutionResult(boolean successful, int exitCode, List<String> resultLines, String processID) {
 
         this.processID = processID;
@@ -50,8 +57,24 @@ public class ExecutionResult extends InfoObject {
             firstLine = null;
     }
 
+    public String getProcessID() {
+        return processID;
+    }
+
+    public int getExitCode() {
+        return exitCode;
+    }
+
+    public String getFirstLine() {
+        return firstLine;
+    }
+
+    public List<String> getResultLines() {
+        return resultLines;
+    }
+
     public boolean isSuccessful() {
-        return exitCode == 0;
+        return successful;
     }
 
     public boolean getSuccessful() {

--- a/src/main/groovy/de/dkfz/roddy/execution/io/ExecutionResult.java
+++ b/src/main/groovy/de/dkfz/roddy/execution/io/ExecutionResult.java
@@ -13,6 +13,9 @@ import java.util.List;
 /**
  * Stores the result of a command execution.
  * Commands can i.e. be executed via ssh or on the local command line.
+ *
+ *  TODO Make ExecutionResult and AsyncExecutionResult common subclasses of an IExecutionResult interface.
+ *
  * @author michael
  */
 public class ExecutionResult extends InfoObject {
@@ -38,10 +41,14 @@ public class ExecutionResult extends InfoObject {
 
     protected final int exitCode;
 
-    /** Contain the results of an execution. Note that the usage of this class is quite inconsistent.
+    /** Contain the results of an execution. Note that the usage of this class is quite inconsistent. In particular
+     *  occasionally the result indicates success, but the process actually failed.
      *
-     * @param successful   Whether the execution was successful. Some tools have exit code == 0 but are yet not successful.
-     * @param exitCode     The actual exit code. (Warning: Often this is zero, because waitFor == false).
+     * @param successful   Whether the execution was successful. Some tools produce an exit code == 0 but may still
+     *                     have failed. A prominent example is the BWA aligner. For this reason the successful field
+     *                     allows specifying success from e.g. standard output or error of the process rather than
+     *                     just the exit code.
+     * @param exitCode     The actual exit code.
      * @param resultLines  This should be the standard output and error (interleaved). (Warning: Often this is only stdout).
      * @param processID    The process ID, if available.
      */

--- a/src/main/groovy/de/dkfz/roddy/execution/io/LocalExecutionHelper.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/io/LocalExecutionHelper.groovy
@@ -62,7 +62,7 @@ class LocalExecutionHelper {
     }
 
     /**
-     * Execute a command using the local command interpreter (For Linux this might be bash)
+     * Execute a command using the local command interpreter Bash (currently fixed).
      *
      * If outputStream is set, the full output is going to this stream. Otherwise it is stored
      * in the returned object.
@@ -71,16 +71,15 @@ class LocalExecutionHelper {
      * @param outputStream
      * @return
      */
-    public static ExecutionResult executeCommandWithExtendedResult(String command, OutputStream outputStream = null) {
+    static ExecutionResult executeCommandWithExtendedResult(String command, OutputStream outputStream = null) {
         //Process process = Roddy.getLocalCommandSet().getShellExecuteCommand(command).execute();
         Process process = ["bash", "-c", command].execute();
 
         //TODO Put to a custom class which can handle things for Windows as well.
         String processID = getProcessID(process)
 
-        List<String> lines = [];
-        if (logger.isVerbosityHigh())
-            println("Executing the command ${command} locally.");
+        List<String> lines = []
+        logger.postRareInfo("Executing the command ${command} locally.")
 
         if (outputStream)
             process.waitForProcessOutput(outputStream, outputStream)


### PR DESCRIPTION
Added an AsyncExecutionResult class for dealing with asynchronous results. This is to prepare fixing a bug in Roddy. All of AsyncExecutionResult's methods block until the results are actually available (because the parent-class interface is synchronous).