### PR TITLE
Reverted ExecutionResult.resultLines to public to keep BatchEuphoria binary dependencies intact.

### DIFF
--- a/src/main/groovy/de/dkfz/roddy/execution/io/ExecutionResult.java
+++ b/src/main/groovy/de/dkfz/roddy/execution/io/ExecutionResult.java
@@ -31,8 +31,9 @@ public class ExecutionResult extends InfoObject {
     protected final boolean successful;
     /**
      * All result lines.
+     * TODO: Make protected. This is public to avoid having to also update BatchEuphoria, which references the field.
      */
-    protected final List<String> resultLines;
+    public final List<String> resultLines;
     /**
      * First line of the result array.
      * Null if no entries are in the array.

--- a/src/main/groovy/de/dkfz/roddy/execution/io/LocalExecutionHelper.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/io/LocalExecutionHelper.groovy
@@ -72,7 +72,6 @@ class LocalExecutionHelper {
      * @return
      */
     static ExecutionResult executeCommandWithExtendedResult(String command, OutputStream outputStream = null) {
-        //Process process = Roddy.getLocalCommandSet().getShellExecuteCommand(command).execute();
         Process process = ["bash", "-c", command].execute();
 
         // TODO Put to a custom class which can handle things for Windows as well.
@@ -82,6 +81,7 @@ class LocalExecutionHelper {
         logger.postRareInfo("Executing the command ${command} locally.")
 
         // TODO This should not return the stderr and stdout intermingled (in contrast to SSHExecutionService).
+        // WARNING: There are no guarantees that stderr is written after stderr or otherwise. Output may be unpredictable!
         if (outputStream)
             process.waitForProcessOutput(outputStream, outputStream)
         else {


### PR DESCRIPTION
Downgrading from public to private broke already compiled code in BatchEuphoria 0.0.7 that accesses the `resultLines` field directly. A recompilation and re-release of BatchEuphoria would have been one option, but the access change actually represented an API-change and because this should just be a bugfix, I reverted the access change and added issue https://github.com/TheRoddyWMS/RoddyToolLib/issues/29.