### PR TITLE
Substituted StringBuilder by StringBuffer for thread-safety

### DIFF
--- a/src/main/groovy/de/dkfz/roddy/execution/io/LocalExecutionHelper.groovy
+++ b/src/main/groovy/de/dkfz/roddy/execution/io/LocalExecutionHelper.groovy
@@ -85,7 +85,7 @@ class LocalExecutionHelper {
         if (outputStream)
             process.waitForProcessOutput(outputStream, outputStream)
         else {
-            StringBuilder sstream = new StringBuilder();
+            StringBuffer sstream = new StringBuffer();
             process.waitForProcessOutput(sstream, sstream);
             lines = sstream.readLines().collect { String l -> return l.toString(); };
         }


### PR DESCRIPTION
StringBuilder is not thread-safe resulting in spurious garbage output in LocalExecutionHelper upnon parallel reading of stdout and stderr.